### PR TITLE
Added support for building using gprbuild and Alire

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/obj/
+/lib/
+/alire/
+/config/

--- a/alire.toml
+++ b/alire.toml
@@ -1,0 +1,11 @@
+name = "openal_ada"
+description = "Ada bindings to OpenAL"
+version = "1.1.1-dev"
+
+authors = ["Mark Raynsford io7m"]
+maintainers = ["Manuel Gomez <mgrojo@gmail.com>"]
+maintainers-logins = ["mgrojo"]
+
+licenses = "ISC"
+website = "https://github.com/io7m/coreland-openal-ada"
+tags = ["audio", "binding", "openal"]

--- a/openal_ada.gpr
+++ b/openal_ada.gpr
@@ -1,0 +1,34 @@
+with "config/openal_ada_config.gpr";
+project Openal_Ada is
+
+   for Library_Name use "Openal_Ada";
+   for Library_Version use Project'Library_Name & ".so." & Openal_Ada_Config.Crate_Version;
+
+   for Source_Dirs use ("./", "config/");
+   for Object_Dir use "obj/" & Openal_Ada_Config.Build_Profile;
+   for Create_Missing_Dirs use "True";
+   for Library_Dir use "lib";
+
+   type Library_Type_Type is ("relocatable", "static", "static-pic");
+   Library_Type : Library_Type_Type :=
+     external ("OPENAL_ADA_LIBRARY_TYPE", external ("LIBRARY_TYPE", "static"));
+   for Library_Kind use Library_Type;
+
+   package Compiler is
+      for Default_Switches ("Ada") use Openal_Ada_Config.Ada_Compiler_Switches;
+   end Compiler;
+
+  package Linker is
+      for Linker_Options use
+        ("-lopenal", "-lalut");
+   end Linker;
+
+   package Binder is
+      for Switches ("Ada") use ("-Es"); --  Symbolic traceback
+   end Binder;
+
+   package Install is
+      for Artifacts (".") use ("share");
+   end Install;
+
+end Openal_Ada;


### PR DESCRIPTION
I had problems building this using `make` so I added support for `gprbuild` and [Alire](https://alire.ada.dev/). I've thought you might be interested in the changes. The `make`  method should still work, since I haven't changed any of the current files.

I only tested this using https://github.com/mgrojo/GtkAda_OpenAL_Doppler_Effect_Sample2

If you want to add it to the [Alire index](https://github.com/alire-project/alire-index), some external crates for `libopenal` and `libalut` should be included as well and added as dependencies.